### PR TITLE
Add LICM pass and enable it for DateAdd call

### DIFF
--- a/QueryEngine/DateTimeIR.cpp
+++ b/QueryEngine/DateTimeIR.cpp
@@ -91,8 +91,12 @@ llvm::Value* CodeGenerator::codegen(const Analyzer::DateaddExpr* dateadd_expr,
     dateadd_args.push_back(cgen_state_->inlineIntNull(datetime_ti));
     dateadd_fname += "Nullable";
   }
-  return cgen_state_->emitExternalCall(
-      dateadd_fname, get_int_type(64, cgen_state_->context_), dateadd_args);
+  return cgen_state_->emitExternalCall(dateadd_fname,
+                                       get_int_type(64, cgen_state_->context_),
+                                       dateadd_args,
+                                       {llvm::Attribute::NoUnwind,
+                                        llvm::Attribute::ReadNone,
+                                        llvm::Attribute::Speculatable});
 }
 
 llvm::Value* CodeGenerator::codegen(const Analyzer::DatediffExpr* datediff_expr,

--- a/QueryEngine/NativeCodegen.cpp
+++ b/QueryEngine/NativeCodegen.cpp
@@ -121,6 +121,7 @@ void optimize_ir(llvm::Function* query_func,
   pass_manager.add(llvm::createInstructionCombiningPass());
   pass_manager.add(llvm::createGlobalOptimizerPass());
 
+  pass_manager.add(llvm::createLICMPass());
   if (co.opt_level_ == ExecutorOptLevel::LoopStrengthReduction) {
     pass_manager.add(llvm::createLoopStrengthReducePass());
   }


### PR DESCRIPTION
Running TPC-H benchmark queries on Omnisci we found that for some queries generated row_func functions have datetime computations (using DateAdd function call) on literals. When row_func is inlined these computations become loop invariant but are not moved out from the loop. In some cases DateAdd call leads to gmtime_r_newlib call which is quite expensive.

This patch add Loop Invariant Code Motion pass to pass manager and add function attributes for DateAdd declaration to correctly identify it as a loop invariant.

This patch gives ~3x speed-up for TPC-H queries Q5, Q10 and ~20x speed-up for Q6, Q12. Actually I could only run 11 of 22 queries of the benchmark so other queries also might be affected.

LICM pass seems to be quite useful and not expensive (it should be linear to total number of statements in loops), so I propose to always use it.