### PR TITLE
Use arithmetic with overflow intrinsics to detect overflows

### DIFF
--- a/QueryEngine/ArithmeticIR.cpp
+++ b/QueryEngine/ArithmeticIR.cpp
@@ -630,7 +630,8 @@ llvm::Value* CodeGenerator::codegenBinOpWithOverflowCheck(
   // In case of null check we have to use NULL result on check fail
   if (null_check) {
     auto phi = cgen_state_->ir_builder_.CreatePHI(ret->getType(), 2);
-    phi->addIncoming(llvm::ConstantInt::get(ret->getType(), inline_int_null_val(ti)), null_check);
+    phi->addIncoming(llvm::ConstantInt::get(ret->getType(), inline_int_null_val(ti)),
+                     null_check);
     phi->addIncoming(ret, val_bb);
     ret = phi;
   }

--- a/QueryEngine/ArithmeticIR.cpp
+++ b/QueryEngine/ArithmeticIR.cpp
@@ -61,7 +61,7 @@ llvm::Value* CodeGenerator::codegenArith(const Analyzer::BinOper* bin_oper,
     CHECK_EQ(lhs_type.get_type(), rhs_type.get_type());
   }
   if (lhs_type.is_integer() || lhs_type.is_decimal() || lhs_type.is_timeinterval()) {
-    return codegenIntArith(bin_oper, lhs_lv, rhs_lv);
+    return codegenIntArith(bin_oper, lhs_lv, rhs_lv, co);
   }
   if (lhs_type.is_fp()) {
     return codegenFpArith(bin_oper, lhs_lv, rhs_lv);
@@ -73,7 +73,8 @@ llvm::Value* CodeGenerator::codegenArith(const Analyzer::BinOper* bin_oper,
 // Handle integer or integer-like (decimal, time, date) operand types.
 llvm::Value* CodeGenerator::codegenIntArith(const Analyzer::BinOper* bin_oper,
                                             llvm::Value* lhs_lv,
-                                            llvm::Value* rhs_lv) {
+                                            llvm::Value* rhs_lv,
+                                            const CompilationOptions& co) {
   const auto lhs = bin_oper->get_left_operand();
   const auto rhs = bin_oper->get_right_operand();
   const auto& lhs_type = lhs->get_type_info();
@@ -88,21 +89,24 @@ llvm::Value* CodeGenerator::codegenIntArith(const Analyzer::BinOper* bin_oper,
                         rhs_lv,
                         null_check_suffix.empty() ? "" : int_typename,
                         null_check_suffix,
-                        oper_type);
+                        oper_type,
+                        co);
     case kPLUS:
       return codegenAdd(bin_oper,
                         lhs_lv,
                         rhs_lv,
                         null_check_suffix.empty() ? "" : int_typename,
                         null_check_suffix,
-                        oper_type);
+                        oper_type,
+                        co);
     case kMULTIPLY:
       return codegenMul(bin_oper,
                         lhs_lv,
                         rhs_lv,
                         null_check_suffix.empty() ? "" : int_typename,
                         null_check_suffix,
-                        oper_type);
+                        oper_type,
+                        co);
     case kDIVIDE:
       return codegenDiv(lhs_lv,
                         rhs_lv,
@@ -209,7 +213,8 @@ llvm::Value* CodeGenerator::codegenAdd(const Analyzer::BinOper* bin_oper,
                                        llvm::Value* rhs_lv,
                                        const std::string& null_typename,
                                        const std::string& null_check_suffix,
-                                       const SQLTypeInfo& ti) {
+                                       const SQLTypeInfo& ti,
+                                       const CompilationOptions& co) {
   CHECK_EQ(lhs_lv->getType(), rhs_lv->getType());
   CHECK(ti.is_integer() || ti.is_decimal() || ti.is_timeinterval());
   llvm::Value* chosen_max{nullptr};
@@ -219,15 +224,47 @@ llvm::Value* CodeGenerator::codegenAdd(const Analyzer::BinOper* bin_oper,
       !checkExpressionRanges(bin_oper,
                              static_cast<llvm::ConstantInt*>(chosen_min)->getSExtValue(),
                              static_cast<llvm::ConstantInt*>(chosen_max)->getSExtValue());
-  llvm::Value* ret{nullptr};
+
+  if (need_overflow_check && co.device_type_ == ExecutorDeviceType::CPU) {
+    return codegenBinOpWithOverflowForCPU(
+        bin_oper, lhs_lv, rhs_lv, null_check_suffix, ti);
+  }
+
+  llvm::BasicBlock* add_ok{nullptr};
+  llvm::BasicBlock* add_fail{nullptr};
   if (need_overflow_check) {
-    ret = codegenBinOpWithOverflowCheck(bin_oper, lhs_lv, rhs_lv, null_check_suffix, ti);
-  } else {
-    ret = null_check_suffix.empty()
-              ? cgen_state_->ir_builder_.CreateAdd(lhs_lv, rhs_lv)
-              : cgen_state_->emitCall(
-                    "add_" + null_typename + null_check_suffix,
-                    {lhs_lv, rhs_lv, cgen_state_->llInt(inline_int_null_val(ti))});
+    cgen_state_->needs_error_check_ = true;
+    add_ok =
+        llvm::BasicBlock::Create(cgen_state_->context_, "add_ok", cgen_state_->row_func_);
+    if (!null_check_suffix.empty()) {
+      codegenSkipOverflowCheckForNull(lhs_lv, rhs_lv, add_ok, ti);
+    }
+    add_fail = llvm::BasicBlock::Create(
+        cgen_state_->context_, "add_fail", cgen_state_->row_func_);
+    llvm::Value* detected{nullptr};
+    auto const_zero = llvm::ConstantInt::get(lhs_lv->getType(), 0, true);
+    auto overflow = cgen_state_->ir_builder_.CreateAnd(
+        cgen_state_->ir_builder_.CreateICmpSGT(lhs_lv, const_zero),
+        cgen_state_->ir_builder_.CreateICmpSGT(
+            rhs_lv, cgen_state_->ir_builder_.CreateSub(chosen_max, lhs_lv)));
+    auto underflow = cgen_state_->ir_builder_.CreateAnd(
+        cgen_state_->ir_builder_.CreateICmpSLT(lhs_lv, const_zero),
+        cgen_state_->ir_builder_.CreateICmpSLT(
+            rhs_lv, cgen_state_->ir_builder_.CreateSub(chosen_min, lhs_lv)));
+    detected = cgen_state_->ir_builder_.CreateOr(overflow, underflow);
+    cgen_state_->ir_builder_.CreateCondBr(detected, add_fail, add_ok);
+    cgen_state_->ir_builder_.SetInsertPoint(add_ok);
+  }
+  auto ret = null_check_suffix.empty()
+                 ? cgen_state_->ir_builder_.CreateAdd(lhs_lv, rhs_lv)
+                 : cgen_state_->emitCall(
+                       "add_" + null_typename + null_check_suffix,
+                       {lhs_lv, rhs_lv, cgen_state_->llInt(inline_int_null_val(ti))});
+  if (need_overflow_check) {
+    cgen_state_->ir_builder_.SetInsertPoint(add_fail);
+    cgen_state_->ir_builder_.CreateRet(
+        cgen_state_->llInt(Executor::ERR_OVERFLOW_OR_UNDERFLOW));
+    cgen_state_->ir_builder_.SetInsertPoint(add_ok);
   }
   return ret;
 }
@@ -237,7 +274,8 @@ llvm::Value* CodeGenerator::codegenSub(const Analyzer::BinOper* bin_oper,
                                        llvm::Value* rhs_lv,
                                        const std::string& null_typename,
                                        const std::string& null_check_suffix,
-                                       const SQLTypeInfo& ti) {
+                                       const SQLTypeInfo& ti,
+                                       const CompilationOptions& co) {
   CHECK_EQ(lhs_lv->getType(), rhs_lv->getType());
   CHECK(ti.is_integer() || ti.is_decimal() || ti.is_timeinterval());
   llvm::Value* chosen_max{nullptr};
@@ -247,15 +285,49 @@ llvm::Value* CodeGenerator::codegenSub(const Analyzer::BinOper* bin_oper,
       !checkExpressionRanges(bin_oper,
                              static_cast<llvm::ConstantInt*>(chosen_min)->getSExtValue(),
                              static_cast<llvm::ConstantInt*>(chosen_max)->getSExtValue());
-  llvm::Value* ret;
+
+  if (need_overflow_check && co.device_type_ == ExecutorDeviceType::CPU) {
+    return codegenBinOpWithOverflowForCPU(
+        bin_oper, lhs_lv, rhs_lv, null_check_suffix, ti);
+  }
+
+  llvm::BasicBlock* sub_ok{nullptr};
+  llvm::BasicBlock* sub_fail{nullptr};
   if (need_overflow_check) {
-    ret = codegenBinOpWithOverflowCheck(bin_oper, lhs_lv, rhs_lv, null_check_suffix, ti);
-  } else {
-    ret = null_check_suffix.empty()
-              ? cgen_state_->ir_builder_.CreateSub(lhs_lv, rhs_lv)
-              : cgen_state_->emitCall(
-                    "sub_" + null_typename + null_check_suffix,
-                    {lhs_lv, rhs_lv, cgen_state_->llInt(inline_int_null_val(ti))});
+    cgen_state_->needs_error_check_ = true;
+    sub_ok =
+        llvm::BasicBlock::Create(cgen_state_->context_, "sub_ok", cgen_state_->row_func_);
+    if (!null_check_suffix.empty()) {
+      codegenSkipOverflowCheckForNull(lhs_lv, rhs_lv, sub_ok, ti);
+    }
+    sub_fail = llvm::BasicBlock::Create(
+        cgen_state_->context_, "sub_fail", cgen_state_->row_func_);
+    llvm::Value* detected{nullptr};
+    auto const_zero = llvm::ConstantInt::get(lhs_lv->getType(), 0, true);
+    auto overflow = cgen_state_->ir_builder_.CreateAnd(
+        cgen_state_->ir_builder_.CreateICmpSLT(
+            rhs_lv, const_zero),  // sub going up, check the max
+        cgen_state_->ir_builder_.CreateICmpSGT(
+            lhs_lv, cgen_state_->ir_builder_.CreateAdd(chosen_max, rhs_lv)));
+    auto underflow = cgen_state_->ir_builder_.CreateAnd(
+        cgen_state_->ir_builder_.CreateICmpSGT(
+            rhs_lv, const_zero),  // sub going down, check the min
+        cgen_state_->ir_builder_.CreateICmpSLT(
+            lhs_lv, cgen_state_->ir_builder_.CreateAdd(chosen_min, rhs_lv)));
+    detected = cgen_state_->ir_builder_.CreateOr(overflow, underflow);
+    cgen_state_->ir_builder_.CreateCondBr(detected, sub_fail, sub_ok);
+    cgen_state_->ir_builder_.SetInsertPoint(sub_ok);
+  }
+  auto ret = null_check_suffix.empty()
+                 ? cgen_state_->ir_builder_.CreateSub(lhs_lv, rhs_lv)
+                 : cgen_state_->emitCall(
+                       "sub_" + null_typename + null_check_suffix,
+                       {lhs_lv, rhs_lv, cgen_state_->llInt(inline_int_null_val(ti))});
+  if (need_overflow_check) {
+    cgen_state_->ir_builder_.SetInsertPoint(sub_fail);
+    cgen_state_->ir_builder_.CreateRet(
+        cgen_state_->llInt(Executor::ERR_OVERFLOW_OR_UNDERFLOW));
+    cgen_state_->ir_builder_.SetInsertPoint(sub_ok);
   }
   return ret;
 }
@@ -282,6 +354,7 @@ llvm::Value* CodeGenerator::codegenMul(const Analyzer::BinOper* bin_oper,
                                        const std::string& null_typename,
                                        const std::string& null_check_suffix,
                                        const SQLTypeInfo& ti,
+                                       const CompilationOptions& co,
                                        bool downscale) {
   CHECK_EQ(lhs_lv->getType(), rhs_lv->getType());
   CHECK(ti.is_integer() || ti.is_decimal() || ti.is_timeinterval());
@@ -292,17 +365,57 @@ llvm::Value* CodeGenerator::codegenMul(const Analyzer::BinOper* bin_oper,
       !checkExpressionRanges(bin_oper,
                              static_cast<llvm::ConstantInt*>(chosen_min)->getSExtValue(),
                              static_cast<llvm::ConstantInt*>(chosen_max)->getSExtValue());
-  llvm::Value* ret{nullptr};
-  if (need_overflow_check) {
-    ret = codegenBinOpWithOverflowCheck(bin_oper, lhs_lv, rhs_lv, null_check_suffix, ti);
-  } else {
-    ret = null_check_suffix.empty()
-              ? cgen_state_->ir_builder_.CreateMul(lhs_lv, rhs_lv)
-              : cgen_state_->emitCall(
-                    "mul_" + null_typename + null_check_suffix,
-                    {lhs_lv, rhs_lv, cgen_state_->llInt(inline_int_null_val(ti))});
+
+  if (need_overflow_check && co.device_type_ == ExecutorDeviceType::CPU) {
+    return codegenBinOpWithOverflowForCPU(
+        bin_oper, lhs_lv, rhs_lv, null_check_suffix, ti);
   }
 
+  llvm::BasicBlock* mul_ok{nullptr};
+  llvm::BasicBlock* mul_fail{nullptr};
+  if (need_overflow_check) {
+    cgen_state_->needs_error_check_ = true;
+    mul_ok =
+        llvm::BasicBlock::Create(cgen_state_->context_, "mul_ok", cgen_state_->row_func_);
+    if (!null_check_suffix.empty()) {
+      codegenSkipOverflowCheckForNull(lhs_lv, rhs_lv, mul_ok, ti);
+    }
+    mul_fail = llvm::BasicBlock::Create(
+        cgen_state_->context_, "mul_fail", cgen_state_->row_func_);
+    auto mul_check = llvm::BasicBlock::Create(
+        cgen_state_->context_, "mul_check", cgen_state_->row_func_);
+    auto const_zero = llvm::ConstantInt::get(rhs_lv->getType(), 0, true);
+    cgen_state_->ir_builder_.CreateCondBr(
+        cgen_state_->ir_builder_.CreateICmpEQ(rhs_lv, const_zero), mul_ok, mul_check);
+    cgen_state_->ir_builder_.SetInsertPoint(mul_check);
+    auto rhs_is_negative_lv = cgen_state_->ir_builder_.CreateICmpSLT(rhs_lv, const_zero);
+    auto positive_rhs_lv = cgen_state_->ir_builder_.CreateSelect(
+        rhs_is_negative_lv, cgen_state_->ir_builder_.CreateNeg(rhs_lv), rhs_lv);
+    auto adjusted_lhs_lv = cgen_state_->ir_builder_.CreateSelect(
+        rhs_is_negative_lv, cgen_state_->ir_builder_.CreateNeg(lhs_lv), lhs_lv);
+    auto detected = cgen_state_->ir_builder_.CreateOr(  // overflow
+        cgen_state_->ir_builder_.CreateICmpSGT(
+            adjusted_lhs_lv,
+            cgen_state_->ir_builder_.CreateSDiv(chosen_max, positive_rhs_lv)),
+        // underflow
+        cgen_state_->ir_builder_.CreateICmpSLT(
+            adjusted_lhs_lv,
+            cgen_state_->ir_builder_.CreateSDiv(chosen_min, positive_rhs_lv)));
+    cgen_state_->ir_builder_.CreateCondBr(detected, mul_fail, mul_ok);
+    cgen_state_->ir_builder_.SetInsertPoint(mul_ok);
+  }
+  const auto ret =
+      null_check_suffix.empty()
+          ? cgen_state_->ir_builder_.CreateMul(lhs_lv, rhs_lv)
+          : cgen_state_->emitCall(
+                "mul_" + null_typename + null_check_suffix,
+                {lhs_lv, rhs_lv, cgen_state_->llInt(inline_int_null_val(ti))});
+  if (need_overflow_check) {
+    cgen_state_->ir_builder_.SetInsertPoint(mul_fail);
+    cgen_state_->ir_builder_.CreateRet(
+        cgen_state_->llInt(Executor::ERR_OVERFLOW_OR_UNDERFLOW));
+    cgen_state_->ir_builder_.SetInsertPoint(mul_ok);
+  }
   return ret;
 }
 
@@ -573,7 +686,28 @@ llvm::Value* CodeGenerator::codegenUMinus(const Analyzer::UOper* uoper,
   return ret;
 }
 
-llvm::Value* CodeGenerator::codegenBinOpWithOverflowCheck(
+llvm::Function* CodeGenerator::getArithWithOverflowFunction(
+    const Analyzer::BinOper* bin_oper,
+    llvm::Type* type) {
+  llvm::Intrinsic::ID fn_id{llvm::Intrinsic::not_intrinsic};
+  switch (bin_oper->get_optype()) {
+    case kMINUS:
+      fn_id = llvm::Intrinsic::ssub_with_overflow;
+      break;
+    case kPLUS:
+      fn_id = llvm::Intrinsic::sadd_with_overflow;
+      break;
+    case kMULTIPLY:
+      fn_id = llvm::Intrinsic::smul_with_overflow;
+      break;
+    default:
+      LOG(FATAL) << "unexpected arith with overflow optype: " << bin_oper->toString();
+  }
+
+  return llvm::Intrinsic::getDeclaration(cgen_state_->module_, fn_id, type);
+}
+
+llvm::Value* CodeGenerator::codegenBinOpWithOverflowForCPU(
     const Analyzer::BinOper* bin_oper,
     llvm::Value* lhs_lv,
     llvm::Value* rhs_lv,
@@ -581,29 +715,10 @@ llvm::Value* CodeGenerator::codegenBinOpWithOverflowCheck(
     const SQLTypeInfo& ti) {
   cgen_state_->needs_error_check_ = true;
 
-  std::string bb_prefix;
-  llvm::Intrinsic::ID fn_id;
-  switch (bin_oper->get_optype()) {
-    case kMINUS:
-      bb_prefix = "sub";
-      fn_id = llvm::Intrinsic::ssub_with_overflow;
-      break;
-    case kPLUS:
-      bb_prefix = "add";
-      fn_id = llvm::Intrinsic::sadd_with_overflow;
-      break;
-    case kMULTIPLY:
-      bb_prefix = "mul";
-      fn_id = llvm::Intrinsic::smul_with_overflow;
-      break;
-    default:
-      CHECK(false);
-  }
-
-  llvm::BasicBlock* check_ok = llvm::BasicBlock::Create(
-      cgen_state_->context_, bb_prefix + "_ok", cgen_state_->row_func_);
+  llvm::BasicBlock* check_ok =
+      llvm::BasicBlock::Create(cgen_state_->context_, "ovf_ok", cgen_state_->row_func_);
   llvm::BasicBlock* check_fail = llvm::BasicBlock::Create(
-      cgen_state_->context_, bb_prefix + "_fail", cgen_state_->row_func_);
+      cgen_state_->context_, "ovf_detected", cgen_state_->row_func_);
   llvm::BasicBlock* null_check{nullptr};
 
   if (!null_check_suffix.empty()) {
@@ -612,8 +727,7 @@ llvm::Value* CodeGenerator::codegenBinOpWithOverflowCheck(
   }
 
   // Compute result and overflow flag
-  auto func =
-      llvm::Intrinsic::getDeclaration(cgen_state_->module_, fn_id, {lhs_lv->getType()});
+  auto func = getArithWithOverflowFunction(bin_oper, lhs_lv->getType());
   auto ret_and_overflow = cgen_state_->ir_builder_.CreateCall(func, {lhs_lv, rhs_lv});
   auto ret = cgen_state_->ir_builder_.CreateExtractValue(ret_and_overflow, {0});
   auto overflow = cgen_state_->ir_builder_.CreateExtractValue(ret_and_overflow, {1});

--- a/QueryEngine/ArithmeticIR.cpp
+++ b/QueryEngine/ArithmeticIR.cpp
@@ -686,7 +686,7 @@ llvm::Value* CodeGenerator::codegenUMinus(const Analyzer::UOper* uoper,
   return ret;
 }
 
-llvm::Function* CodeGenerator::getArithWithOverflowFunction(
+llvm::Function* CodeGenerator::getArithWithOverflowIntrinsic(
     const Analyzer::BinOper* bin_oper,
     llvm::Type* type) {
   llvm::Intrinsic::ID fn_id{llvm::Intrinsic::not_intrinsic};
@@ -727,7 +727,7 @@ llvm::Value* CodeGenerator::codegenBinOpWithOverflowForCPU(
   }
 
   // Compute result and overflow flag
-  auto func = getArithWithOverflowFunction(bin_oper, lhs_lv->getType());
+  auto func = getArithWithOverflowIntrinsic(bin_oper, lhs_lv->getType());
   auto ret_and_overflow = cgen_state_->ir_builder_.CreateCall(func, {lhs_lv, rhs_lv});
   auto ret = cgen_state_->ir_builder_.CreateExtractValue(ret_and_overflow, {0});
   auto overflow = cgen_state_->ir_builder_.CreateExtractValue(ret_and_overflow, {1});

--- a/QueryEngine/CodeGenerator.h
+++ b/QueryEngine/CodeGenerator.h
@@ -233,7 +233,10 @@ class CodeGenerator {
       const bool fetch_column,
       const CompilationOptions& co);
 
-  llvm::Value* codegenIntArith(const Analyzer::BinOper*, llvm::Value*, llvm::Value*);
+  llvm::Value* codegenIntArith(const Analyzer::BinOper*,
+                               llvm::Value*,
+                               llvm::Value*,
+                               const CompilationOptions&);
 
   llvm::Value* codegenFpArith(const Analyzer::BinOper*, llvm::Value*, llvm::Value*);
 
@@ -265,14 +268,16 @@ class CodeGenerator {
                           llvm::Value*,
                           const std::string& null_typename,
                           const std::string& null_check_suffix,
-                          const SQLTypeInfo&);
+                          const SQLTypeInfo&,
+                          const CompilationOptions&);
 
   llvm::Value* codegenSub(const Analyzer::BinOper*,
                           llvm::Value*,
                           llvm::Value*,
                           const std::string& null_typename,
                           const std::string& null_check_suffix,
-                          const SQLTypeInfo&);
+                          const SQLTypeInfo&,
+                          const CompilationOptions&);
 
   void codegenSkipOverflowCheckForNull(llvm::Value* lhs_lv,
                                        llvm::Value* rhs_lv,
@@ -285,6 +290,7 @@ class CodeGenerator {
                           const std::string& null_typename,
                           const std::string& null_check_suffix,
                           const SQLTypeInfo&,
+                          const CompilationOptions&,
                           bool downscale = true);
 
   llvm::Value* codegenDiv(llvm::Value*,
@@ -406,11 +412,14 @@ class CodeGenerator {
       const std::unordered_map<llvm::Value*, llvm::Value*>&,
       const CompilationOptions&);
 
-  llvm::Value* codegenBinOpWithOverflowCheck(const Analyzer::BinOper* bin_oper,
-                                             llvm::Value* lhs_lv,
-                                             llvm::Value* rhs_lv,
-                                             const std::string& null_check_suffix,
-                                             const SQLTypeInfo& ti);
+  llvm::Function* getArithWithOverflowFunction(const Analyzer::BinOper* bin_oper,
+                                               llvm::Type* type);
+
+  llvm::Value* codegenBinOpWithOverflowForCPU(const Analyzer::BinOper* bin_oper,
+                                              llvm::Value* lhs_lv,
+                                              llvm::Value* rhs_lv,
+                                              const std::string& null_check_suffix,
+                                              const SQLTypeInfo& ti);
 
   Executor* executor_;
 

--- a/QueryEngine/CodeGenerator.h
+++ b/QueryEngine/CodeGenerator.h
@@ -406,6 +406,12 @@ class CodeGenerator {
       const std::unordered_map<llvm::Value*, llvm::Value*>&,
       const CompilationOptions&);
 
+  llvm::Value* codegenBinOpWithOverflowCheck(const Analyzer::BinOper* bin_oper,
+                                             llvm::Value* lhs_lv,
+                                             llvm::Value* rhs_lv,
+                                             const std::string& null_check_suffix,
+                                             const SQLTypeInfo& ti);
+
   Executor* executor_;
 
  protected:

--- a/QueryEngine/CodeGenerator.h
+++ b/QueryEngine/CodeGenerator.h
@@ -412,9 +412,15 @@ class CodeGenerator {
       const std::unordered_map<llvm::Value*, llvm::Value*>&,
       const CompilationOptions&);
 
-  llvm::Function* getArithWithOverflowFunction(const Analyzer::BinOper* bin_oper,
-                                               llvm::Type* type);
+  // Return LLVM intrinsic providing fast arithmetic with overflow check
+  // for the given binary operation.
+  llvm::Function* getArithWithOverflowIntrinsic(const Analyzer::BinOper* bin_oper,
+                                                llvm::Type* type);
 
+  // Generate code for the given binary operation with overflow check.
+  // Signed integer add, sub and mul operations are supported. Overflow
+  // check is performed using LLVM arithmetic intrinsics which are not
+  // supported for GPU. Return the IR value which holds operation result.
   llvm::Value* codegenBinOpWithOverflowForCPU(const Analyzer::BinOper* bin_oper,
                                               llvm::Value* lhs_lv,
                                               llvm::Value* rhs_lv,


### PR DESCRIPTION
This patch utilizes arithmetic with overflow LLVM intrinsics to detect overflows/underflows. On x86 CPU this allows to use overflow bit flag instead of doing reverse operations for the check. This is especially useful for multiplication case. TPC-H query Q1 has multiplication with overflow check and this patch gives it 6.4x speed-up.

I'm not sure about implications for CUDA. Used intrinsics are not x86 specific so I expect them to work on all platforms. Unfortunately I don't have CUDA on my server to test it.