### PR TITLE
Multi-line db-query-list file statements, added --exit-after-warmup 

### DIFF
--- a/MapDServer.cpp
+++ b/MapDServer.cpp
@@ -39,10 +39,12 @@
 #include "Shared/scope.h"
 
 #include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/locale/generator.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/program_options.hpp>
+
 #include <csignal>
 #include <sstream>
 #include <thread>
@@ -218,14 +220,26 @@ void run_warmup_queries(mapd::shared_ptr<MapDHandler> handler,
         TQueryResult ret;
         std::string single_query;
         while (std::getline(query_file, single_query)) {
+          boost::algorithm::trim(single_query);
           if (single_query.length() == 0) {
             continue;
           }
-          if (single_query.compare("}") == 0) {
+          if (single_query[0] == '}') {
             single_query.clear();
             break;
           }
-          g_warmup_handler->sql_execute(ret, sessionId, single_query, true, "", -1, -1);
+          if (single_query.find(';') == single_query.npos) {
+            std::string multiline_query;
+            std::getline(query_file, multiline_query, ';');
+            single_query += multiline_query;
+          }
+
+          try {
+            g_warmup_handler->sql_execute(ret, sessionId, single_query, true, "", -1, -1);
+          } catch (...) {
+            LOG(WARNING) << "Exception while executing '" << single_query
+                         << "', ignoring";
+          }
           single_query.clear();
         }
 
@@ -299,6 +313,10 @@ class MapDProgramOptions {
    * path to file containing warmup queries list
    */
   std::string db_query_file = {""};
+  /**
+   * exit after warmup
+   */
+  bool exit_after_warmup = false;
   /**
    * Inactive session tolerance in mins (60 mins)
    */
@@ -400,6 +418,10 @@ void MapDProgramOptions::fillOptions() {
   help_desc.add_options()("db-query-list",
                           po::value<std::string>(&db_query_file),
                           "Path to file containing OmniSci warmup queries.");
+  help_desc.add_options()(
+      "exit-after-warmup",
+      po::value<bool>(&exit_after_warmup)->default_value(false)->implicit_value(true),
+      "Exit after OmniSci warmup queries.");
   help_desc.add_options()("dynamic-watchdog-time-limit",
                           po::value<unsigned>(&dynamic_watchdog_time_limit)
                               ->default_value(dynamic_watchdog_time_limit)
@@ -1123,6 +1145,8 @@ int startMapdServer(MapDProgramOptions& prog_config_opts, bool start_http_server
     // run warm up queries if any exists
     run_warmup_queries(
         g_mapd_handler, prog_config_opts.base_path, prog_config_opts.db_query_file);
+    if (prog_config_opts.exit_after_warmup)
+      g_running = false;
 
     mapd::shared_ptr<TServerTransport> httpServerTransport(httpServerSocket);
     mapd::shared_ptr<TTransportFactory> httpTransportFactory(

--- a/MapDServer.cpp
+++ b/MapDServer.cpp
@@ -1145,8 +1145,9 @@ int startMapdServer(MapDProgramOptions& prog_config_opts, bool start_http_server
     // run warm up queries if any exists
     run_warmup_queries(
         g_mapd_handler, prog_config_opts.base_path, prog_config_opts.db_query_file);
-    if (prog_config_opts.exit_after_warmup)
+    if (prog_config_opts.exit_after_warmup) {
       g_running = false;
+    }
 
     mapd::shared_ptr<TServerTransport> httpServerTransport(httpServerSocket);
     mapd::shared_ptr<TTransportFactory> httpTransportFactory(


### PR DESCRIPTION
so the server can be run as:
  $ omnisci_server --db-query-list file.sql --exit-after-warmup

@gshimansky @fexolm 