### PR TITLE
use zero-copy fetch for columnar result sets when possible

### DIFF
--- a/QueryEngine/ResultSet.cpp
+++ b/QueryEngine/ResultSet.cpp
@@ -899,6 +899,18 @@ bool ResultSet::isDirectColumnarConversionPossible() const {
   }
 }
 
+bool ResultSet::isZeroCopyColumnarConversionPossible(size_t column_idx) const {
+  return query_mem_desc_.didOutputColumnar() &&
+         query_mem_desc_.getQueryDescriptionType() == QueryDescriptionType::Projection &&
+         appended_storage_.empty() && storage_ &&
+         (lazy_fetch_info_.empty() || !lazy_fetch_info_[column_idx].is_lazily_fetched);
+}
+
+const int8_t* ResultSet::getColumnarBuffer(size_t column_idx) const {
+  CHECK(isZeroCopyColumnarConversionPossible(column_idx));
+  return storage_->getUnderlyingBuffer() + query_mem_desc_.getColOffInBytes(column_idx);
+}
+
 // returns a bitmap (and total number) of all single slot targets
 std::tuple<std::vector<bool>, size_t> ResultSet::getSingleSlotTargetBitmap() const {
   std::vector<bool> target_bitmap(targets_.size(), true);

--- a/QueryEngine/ResultSet.h
+++ b/QueryEngine/ResultSet.h
@@ -501,6 +501,9 @@ class ResultSet {
 
   bool didOutputColumnar() const { return this->query_mem_desc_.didOutputColumnar(); }
 
+  bool isZeroCopyColumnarConversionPossible(size_t column_idx) const;
+  const int8_t* getColumnarBuffer(size_t column_idx) const;
+
   QueryDescriptionType getQueryDescriptionType() const {
     return query_mem_desc_.getQueryDescriptionType();
   }


### PR DESCRIPTION
Use zero-copy column fetch from columnar result sets