### PR TITLE
avoid full scan in ResultSet::rowCount when possible

### DIFF
--- a/QueryEngine/ResultSet.cpp
+++ b/QueryEngine/ResultSet.cpp
@@ -322,6 +322,10 @@ size_t ResultSet::rowCount(const bool force_parallel) const {
   if (!storage_) {
     return 0;
   }
+  if (permutation_.empty() &&
+      query_mem_desc_.getQueryDescriptionType() == QueryDescriptionType::Projection) {
+    return binSearchRowCount();
+  }
   if (force_parallel || entryCount() > 20000) {
     return parallelRowCount();
   }
@@ -342,6 +346,24 @@ size_t ResultSet::rowCount(const bool force_parallel) const {
 void ResultSet::setCachedRowCount(const size_t row_count) const {
   CHECK(cached_row_count_ == -1 || cached_row_count_ == static_cast<ssize_t>(row_count));
   cached_row_count_ = row_count;
+}
+
+size_t ResultSet::binSearchRowCount() const {
+  if (!storage_) {
+    return 0;
+  }
+
+  size_t row_count = storage_->binSearchRowCount();
+  for (auto& s : appended_storage_) {
+    row_count += s->binSearchRowCount();
+  }
+
+  if (keep_first_ + drop_first_) {
+    const auto limited_row_count = std::min(keep_first_ + drop_first_, row_count);
+    return limited_row_count < drop_first_ ? 0 : limited_row_count - drop_first_;
+  }
+
+  return row_count;
 }
 
 size_t ResultSet::parallelRowCount() const {

--- a/QueryEngine/ResultSet.h
+++ b/QueryEngine/ResultSet.h
@@ -200,6 +200,8 @@ class ResultSetStorage {
 
   int64_t mappedPtr(const int64_t) const;
 
+  size_t binSearchRowCount() const;
+
   const std::vector<TargetInfo> targets_;
   QueryMemoryDescriptor query_mem_desc_;
   int8_t* buff_;
@@ -567,6 +569,8 @@ class ResultSet {
   ENTRY_TYPE getColumnarBaselineEntryAt(const size_t row_idx,
                                         const size_t target_idx,
                                         const size_t slot_idx) const;
+
+  size_t binSearchRowCount() const;
 
   size_t parallelRowCount() const;
 

--- a/QueryEngine/ResultSetIteration.cpp
+++ b/QueryEngine/ResultSetIteration.cpp
@@ -2176,7 +2176,7 @@ bool ResultSetStorage::isEmptyEntryColumnar(const size_t entry_idx,
 namespace {
 
 template <typename T>
-inline size_t makeBinSearch(size_t l, size_t r, T&& is_empty_fn) {
+inline size_t make_bin_search(size_t l, size_t r, T&& is_empty_fn) {
   // Avoid search if there are no empty keys.
   if (!is_empty_fn(r - 1)) {
     return r;
@@ -2199,18 +2199,18 @@ inline size_t makeBinSearch(size_t l, size_t r, T&& is_empty_fn) {
 
 size_t ResultSetStorage::binSearchRowCount() const {
   CHECK(query_mem_desc_.getQueryDescriptionType() == QueryDescriptionType::Projection);
-  CHECK_EQ(query_mem_desc_.getEffectiveKeyWidth(), 8);
+  CHECK_EQ(query_mem_desc_.getEffectiveKeyWidth(), size_t(8));
 
   if (!query_mem_desc_.getEntryCount()) {
     return 0;
   }
 
   if (query_mem_desc_.didOutputColumnar()) {
-    return makeBinSearch(0, query_mem_desc_.getEntryCount(), [this](size_t idx) {
+    return make_bin_search(0, query_mem_desc_.getEntryCount(), [this](size_t idx) {
       return reinterpret_cast<const int64_t*>(buff_)[idx] == EMPTY_KEY_64;
     });
   } else {
-    return makeBinSearch(0, query_mem_desc_.getEntryCount(), [this](size_t idx) {
+    return make_bin_search(0, query_mem_desc_.getEntryCount(), [this](size_t idx) {
       const auto keys_ptr = row_ptr_rowwise(buff_, query_mem_desc_, idx);
       return *reinterpret_cast<const int64_t*>(keys_ptr) == EMPTY_KEY_64;
     });

--- a/QueryEngine/ResultSetIteration.cpp
+++ b/QueryEngine/ResultSetIteration.cpp
@@ -2173,6 +2173,50 @@ bool ResultSetStorage::isEmptyEntryColumnar(const size_t entry_idx,
   return false;
 }
 
+namespace {
+
+template <typename T>
+inline size_t makeBinSearch(size_t l, size_t r, T&& is_empty_fn) {
+  // Avoid search if there are no empty keys.
+  if (!is_empty_fn(r - 1)) {
+    return r;
+  }
+
+  --r;
+  while (l != r) {
+    size_t c = (l + r) / 2;
+    if (is_empty_fn(c)) {
+      r = c;
+    } else {
+      l = c + 1;
+    }
+  }
+
+  return r;
+}
+
+}  // namespace
+
+size_t ResultSetStorage::binSearchRowCount() const {
+  CHECK(query_mem_desc_.getQueryDescriptionType() == QueryDescriptionType::Projection);
+  CHECK_EQ(query_mem_desc_.getEffectiveKeyWidth(), 8);
+
+  if (!query_mem_desc_.getEntryCount()) {
+    return 0;
+  }
+
+  if (query_mem_desc_.didOutputColumnar()) {
+    return makeBinSearch(0, query_mem_desc_.getEntryCount(), [this](size_t idx) {
+      return reinterpret_cast<const int64_t*>(buff_)[idx] == EMPTY_KEY_64;
+    });
+  } else {
+    return makeBinSearch(0, query_mem_desc_.getEntryCount(), [this](size_t idx) {
+      const auto keys_ptr = row_ptr_rowwise(buff_, query_mem_desc_, idx);
+      return *reinterpret_cast<const int64_t*>(keys_ptr) == EMPTY_KEY_64;
+    });
+  }
+}
+
 bool ResultSetStorage::isEmptyEntry(const size_t entry_idx) const {
   return isEmptyEntry(entry_idx, buff_);
 }


### PR DESCRIPTION
This patch speeds up row count computation for projections using a binary search instead of a linear scan.