### PR TITLE
allow decimal columns in hash joins

### DIFF
--- a/QueryEngine/JoinHashTable.cpp
+++ b/QueryEngine/JoinHashTable.cpp
@@ -49,9 +49,15 @@ InnerOuter normalize_column_pair(const Analyzer::Expr* lhs,
       throw HashJoinFail("Equijoin types must be identical, found: " +
                          lhs_ti.get_type_name() + ", " + rhs_ti.get_type_name());
     }
-    if (!lhs_ti.is_integer() && !lhs_ti.is_time() && !lhs_ti.is_string()) {
+    if (!lhs_ti.is_integer() && !lhs_ti.is_time() && !lhs_ti.is_string() &&
+        !lhs_ti.is_decimal()) {
       throw HashJoinFail("Cannot apply hash join to inner column type " +
                          lhs_ti.get_type_name());
+    }
+    // Decimal types should be identical.
+    if (lhs_ti.is_decimal() && (lhs_ti.get_scale() != rhs_ti.get_scale() ||
+                                lhs_ti.get_precision() != rhs_ti.get_precision())) {
+      throw HashJoinFail("Equijoin with different decimal types");
     }
   }
 
@@ -60,6 +66,10 @@ InnerOuter normalize_column_pair(const Analyzer::Expr* lhs,
   if (lhs_ti.is_string() && (static_cast<bool>(lhs_cast) != static_cast<bool>(rhs_cast) ||
                              (lhs_cast && lhs_cast->get_optype() != kCAST) ||
                              (rhs_cast && rhs_cast->get_optype() != kCAST))) {
+    throw HashJoinFail("Cannot use hash join for given expression");
+  }
+  // Casts to decimal are not suported.
+  if (lhs_ti.is_decimal() && (lhs_cast || rhs_cast)) {
     throw HashJoinFail("Cannot use hash join for given expression");
   }
   const auto lhs_col =
@@ -113,6 +123,11 @@ InnerOuter normalize_column_pair(const Analyzer::Expr* lhs,
       !(dynamic_cast<const Analyzer::FunctionOper*>(lhs)) && outer_col
           ? outer_col->get_type_info()
           : outer_ti;
+  // Casts from decimal are not supported.
+  if ((inner_col_real_ti.is_decimal() || outer_col_ti.is_decimal()) &&
+      (lhs_cast || rhs_cast)) {
+    throw HashJoinFail("Cannot use hash join for given expression");
+  }
   if (is_overlaps_join) {
     if (!inner_col_real_ti.is_array()) {
       throw HashJoinFail(
@@ -128,6 +143,7 @@ InnerOuter normalize_column_pair(const Analyzer::Expr* lhs,
     }
   } else {
     if (!(inner_col_real_ti.is_integer() || inner_col_real_ti.is_time() ||
+          inner_col_real_ti.is_decimal() ||
           (inner_col_real_ti.is_string() &&
            inner_col_real_ti.get_compression() == kENCODING_DICT))) {
       throw HashJoinFail(

--- a/Tests/ExecuteTest.cpp
+++ b/Tests/ExecuteTest.cpp
@@ -5509,6 +5509,52 @@ void import_hash_join_test() {
   }
 }
 
+void import_hash_join_decimal_test() {
+  const std::string drop_old_test{"DROP TABLE IF EXISTS hash_join_decimal_test;"};
+  run_ddl_statement(drop_old_test);
+  g_sqlite_comparator.query(drop_old_test);
+
+  std::string replicated_dec{!g_aggregator ? "" : ", PARTITIONS='REPLICATED'"};
+
+  const std::string create_test{
+      "CREATE TABLE hash_join_decimal_test(x DECIMAL(18,2), y DECIMAL(18,3)) "
+      "WITH (fragment_size=2" +
+      replicated_dec + ");"};
+  run_ddl_statement(create_test);
+  g_sqlite_comparator.query(
+      "CREATE TABLE hash_join_decimal_test(x DECIMAL(18,2), y DECIMAL(18,3));");
+  {
+    const std::string insert_query{
+        "INSERT INTO hash_join_decimal_test VALUES(1.00, 1.000);"};
+    run_multiple_agg(insert_query, ExecutorDeviceType::CPU);
+    g_sqlite_comparator.query(insert_query);
+  }
+  {
+    const std::string insert_query{
+        "INSERT INTO hash_join_decimal_test VALUES(2.00, 2.000);"};
+    run_multiple_agg(insert_query, ExecutorDeviceType::CPU);
+    g_sqlite_comparator.query(insert_query);
+  }
+  {
+    const std::string insert_query{
+        "INSERT INTO hash_join_decimal_test VALUES(3.00, 3.000);"};
+    run_multiple_agg(insert_query, ExecutorDeviceType::CPU);
+    g_sqlite_comparator.query(insert_query);
+  }
+  {
+    const std::string insert_query{
+        "INSERT INTO hash_join_decimal_test VALUES(4.00, 4.001);"};
+    run_multiple_agg(insert_query, ExecutorDeviceType::CPU);
+    g_sqlite_comparator.query(insert_query);
+  }
+  {
+    const std::string insert_query{
+        "INSERT INTO hash_join_decimal_test VALUES(10.00, 10.000);"};
+    run_multiple_agg(insert_query, ExecutorDeviceType::CPU);
+    g_sqlite_comparator.query(insert_query);
+  }
+}
+
 void import_coalesce_cols_join_test(const int id, bool with_delete_support) {
   const std::string table_name = "coalesce_cols_test_" + std::to_string(id);
   const std::string drop_old_test{"DROP TABLE IF EXISTS " + table_name + ";"};
@@ -8450,6 +8496,24 @@ TEST(Select, Joins_MultipleOuterExpressions) {
           "b.x;",
           "SELECT COUNT(*) FROM test a, test b WHERE a.o = b.o AND a.x = b.x;",
           dt));
+  }
+}
+
+TEST(Select, Joins_Decimal) {
+  for (auto dt : {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU}) {
+    SKIP_NO_GPU();
+    c("SELECT COUNT(*) FROM hash_join_decimal_test as t1, hash_join_decimal_test as t2 "
+      "WHERE t1.x = t2.x;",
+      dt);
+    c("SELECT COUNT(*) FROM hash_join_decimal_test as t1, hash_join_decimal_test as t2 "
+      "WHERE t1.y = t2.y;",
+      dt);
+    c("SELECT COUNT(*) FROM hash_join_decimal_test as t1, hash_join_decimal_test as t2 "
+      "WHERE t1.x = t2.y;",
+      dt);
+    c("SELECT COUNT(*) FROM hash_join_decimal_test as t1, hash_join_decimal_test as t2 "
+      "WHERE CAST(t1.x as INT) = CAST(t2.y as INT);",
+      dt);
   }
 }
 
@@ -18253,6 +18317,12 @@ int create_and_populate_tables(const bool use_temporary_tables,
     return -EEXIST;
   }
   try {
+    import_hash_join_decimal_test();
+  } catch (...) {
+    LOG(ERROR) << "Failed to (re-)create table 'hash_join_decimal_test'";
+    return -EEXIST;
+  }
+  try {
     import_coalesce_cols_join_test(0, with_delete_support);
     import_coalesce_cols_join_test(1, with_delete_support);
     import_coalesce_cols_join_test(2, with_delete_support);
@@ -18541,6 +18611,9 @@ void drop_tables() {
   const std::string drop_hash_join_test{"DROP TABLE hash_join_test;"};
   run_ddl_statement(drop_hash_join_test);
   g_sqlite_comparator.query(drop_hash_join_test);
+  const std::string drop_hash_join_decimal_test{"DROP TABLE hash_join_decimal_test;"};
+  run_ddl_statement(drop_hash_join_decimal_test);
+  g_sqlite_comparator.query(drop_hash_join_decimal_test);
   const std::string drop_coalesce_join_test_0{"DROP TABLE coalesce_cols_test_0"};
   run_ddl_statement(drop_coalesce_join_test_0);
   g_sqlite_comparator.query(drop_coalesce_join_test_0);


### PR DESCRIPTION
This patch allows hash table usage for equijoins with decimal columns.