### PR TITLE
Fix mapd-deps-arch.sh arrow install, updated arch/PKGBUILD md5sum

### DIFF
--- a/scripts/arch/arrow/PKGBUILD
+++ b/scripts/arch/arrow/PKGBUILD
@@ -16,7 +16,7 @@ makedepends=('cmake' 'boost')
 source=("https://github.com/apache/arrow/archive/apache-arrow-$pkgver.tar.gz"
         '0001-PARQUET-1823-C-Invalid-RowGroup-returned-by-parquet-.patch')
 sha256sums=('d7b3838758a365c8c47d55ab0df1006a70db951c6964440ba354f81f518b8d8d'
-            '478dfbc91459ba1c3c9ecd3def8c9f42ce7c93eb07dbe27a38535a25709f1cf0')
+            'da2f4d3c071c9b18948d73e08febf7f64425c7886daa3914ff220c2e10301be5')
 
 prepare(){
   cd "${srcdir}/$pkgname-apache-$pkgname-$pkgver"

--- a/scripts/mapd-deps-arch.sh
+++ b/scripts/mapd-deps-arch.sh
@@ -41,13 +41,13 @@ yay -S \
 # Package cannot be built in a path that incudes "internal" as a substring.
 ARROW_PKG_DIR=$HOME/omnisci_tmp_arrow
 mkdir -p $ARROW_PKG_DIR
-cp arch/arrow/PKGBUILD $ARROW_PKG_DIR
-pushd $ARROW_PKG_DIR
+cp -r arch/arrow/ $ARROW_PKG_DIR
+pushd $ARROW_PKG_DIR/arrow
 makepkg -cis
 rm -f PKGBUILD
 popd
-mv $ARROW_PKG_DIR/{apache-arrow-*.tar.gz,arrow-*.pkg.tar.xz} arch/arrow/
-rmdir $ARROW_PKG_DIR
+mv $ARROW_PKG_DIR/arrow/{apache-arrow-*.tar.gz,arrow-*.pkg.tar.xz} arch/arrow/
+rm -rf $ARROW_PKG_DIR
 
 # Install SPIRV-Cross
 pushd arch/spirv-cross


### PR DESCRIPTION
Tried to run mapd-deps-arch.sh on an arch Linux and failed. This is an attempt fixing the script.