### PR TITLE
Introduce COMPONENT labels, improving conda build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,6 @@ if(DEFINED ENV{CONDA_PREFIX})
   add_compile_options("-fno-semantic-interposition")
   # Adding `--sysroot=...` resolves `no member named 'signbit' in the global namespace` error:
   set(CMAKE_SYSROOT "$ENV{CONDA_BUILD_SYSROOT}")
-  # Adding sysroot include dir resolves `cassert file not found` error:
-  include_directories(SYSTEM "$ENV{CONDA_BUILD_SYSROOT}/usr/include")
 endif(DEFINED ENV{CONDA_PREFIX})
 
 # force `Release` build type if left unspecified
@@ -727,7 +725,7 @@ add_dependencies(omnisci_server rerun_cmake)
 
 target_link_libraries(omnisci_server mapd_thrift thrift_handler ${MAPD_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${CUDA_LIBRARIES} ${PROFILER_LIBS} ${ZLIB_LIBRARIES} ${LOCALE_LINK_FLAG})
 
-target_link_libraries(initdb mapd_thrift DataMgr ${MAPD_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${CUDA_LIBRARIES} ${ZLIB_LIBRARIES} ${LLVM_LIB_FLAGS})
+target_link_libraries(initdb mapd_thrift DataMgr ${MAPD_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${CUDA_LIBRARIES} ${ZLIB_LIBRARIES})
 
 macro(set_dpkg_arch arch_in arch_out)
   if("${arch_in}" STREQUAL "x86_64")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,26 @@
 # fixme: this should be 3.3, but that breaks static ncurses
 cmake_minimum_required(VERSION 3.2)
 
+set(ENABLE_CONDA OFF)
+if(DEFINED ENV{CONDA_PREFIX})
+  set(ENABLE_CONDA ON)
+  list(APPEND CMAKE_PREFIX_PATH "$ENV{CONDA_PREFIX}")
+  # resolves link issue for zlib 
+  link_directories("$ENV{CONDA_PREFIX}/lib")
+  # various fixes and workarounds
+  add_definitions("-Dsecure_getenv=getenv")
+  # fixes `undefined reference to `boost::system::detail::system_category_instance'`:
+  add_definitions("-DBOOST_ERROR_CODE_HEADER_ONLY")
+  # Adding formating macros
+  add_definitions("-D__STDC_FORMAT_MACROS=1")
+  # fixes always_inline attribute errors
+  add_compile_options("-fno-semantic-interposition")
+  # Adding `--sysroot=...` resolves `no member named 'signbit' in the global namespace` error:
+  set(CMAKE_SYSROOT "$ENV{CONDA_BUILD_SYSROOT}")
+  # Adding sysroot include dir resolves `cassert file not found` error:
+  include_directories(SYSTEM "$ENV{CONDA_BUILD_SYSROOT}/usr/include")
+endif(DEFINED ENV{CONDA_PREFIX})
+
 # force `Release` build type if left unspecified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
@@ -149,9 +169,12 @@ if (ENABLE_GEOS)
 endif()
 
 # fixme: hack works for Homebrew, might not work for Conda
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(ENABLE_CONDA)
+  set(OPENSSL_ROOT_DIR "$ENV{CONDA_PREFIX}")
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )
   set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl/")
 endif()
+
 find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
 
@@ -465,14 +488,7 @@ if(TBB_FOUND)
   list(APPEND TBB_LIBS ${TBB_LIBRARIES})
 endif()
 
-add_custom_command(
-  DEPENDS
-    ${CMAKE_SOURCE_DIR}/omnisci.thrift
-    ${CMAKE_SOURCE_DIR}/common.thrift
-    ${CMAKE_SOURCE_DIR}/completion_hints.thrift
-    ${CMAKE_SOURCE_DIR}/QueryEngine/serialized_result_set.thrift
-    ${CMAKE_SOURCE_DIR}/QueryEngine/extension_functions.thrift
-  OUTPUT
+set(gen_cpp_files
     ${CMAKE_BINARY_DIR}/gen-cpp/OmniSci.cpp
     ${CMAKE_BINARY_DIR}/gen-cpp/OmniSci.h
     ${CMAKE_BINARY_DIR}/gen-cpp/omnisci_constants.cpp
@@ -485,24 +501,23 @@ add_custom_command(
     ${CMAKE_BINARY_DIR}/gen-cpp/serialized_result_set_types.cpp
     ${CMAKE_BINARY_DIR}/gen-cpp/extension_functions_constants.cpp
     ${CMAKE_BINARY_DIR}/gen-cpp/extension_functions_types.cpp
+    ${CMAKE_BINARY_DIR}/gen-cpp/extension_functions_types.h
+)
+add_custom_command(
+  DEPENDS
+    ${CMAKE_SOURCE_DIR}/omnisci.thrift
+    ${CMAKE_SOURCE_DIR}/common.thrift
+    ${CMAKE_SOURCE_DIR}/completion_hints.thrift
+    ${CMAKE_SOURCE_DIR}/QueryEngine/serialized_result_set.thrift
+    ${CMAKE_SOURCE_DIR}/QueryEngine/extension_functions.thrift
+  OUTPUT ${gen_cpp_files}
   COMMAND ${Thrift_EXECUTABLE}
   ARGS -gen cpp -r -o ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/omnisci.thrift)
 list(APPEND ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_BINARY_DIR}/gen-cpp/)
 
-add_library(mapd_thrift
-  ${CMAKE_BINARY_DIR}/gen-cpp/OmniSci.cpp
-  ${CMAKE_BINARY_DIR}/gen-cpp/OmniSci.h
-  ${CMAKE_BINARY_DIR}/gen-cpp/omnisci_constants.cpp
-  ${CMAKE_BINARY_DIR}/gen-cpp/omnisci_types.cpp
-  ${CMAKE_BINARY_DIR}/gen-cpp/common_constants.cpp
-  ${CMAKE_BINARY_DIR}/gen-cpp/common_types.cpp
-  ${CMAKE_BINARY_DIR}/gen-cpp/completion_hints_constants.cpp
-  ${CMAKE_BINARY_DIR}/gen-cpp/completion_hints_types.cpp
-  ${CMAKE_BINARY_DIR}/gen-cpp/serialized_result_set_constants.cpp
-  ${CMAKE_BINARY_DIR}/gen-cpp/serialized_result_set_types.cpp
-  ${CMAKE_BINARY_DIR}/gen-cpp/extension_functions_constants.cpp
-  ${CMAKE_BINARY_DIR}/gen-cpp/extension_functions_types.cpp
-)
+add_custom_target(thrift_gen DEPENDS ${gen_cpp_files})
+
+add_library(mapd_thrift ${gen_cpp_files})
 
 target_compile_options(mapd_thrift PRIVATE -fPIC)
 target_link_libraries(mapd_thrift ${Thrift_LIBRARIES})
@@ -712,7 +727,7 @@ add_dependencies(omnisci_server rerun_cmake)
 
 target_link_libraries(omnisci_server mapd_thrift thrift_handler ${MAPD_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${CUDA_LIBRARIES} ${PROFILER_LIBS} ${ZLIB_LIBRARIES} ${LOCALE_LINK_FLAG})
 
-target_link_libraries(initdb mapd_thrift DataMgr ${MAPD_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${CUDA_LIBRARIES} ${ZLIB_LIBRARIES})
+target_link_libraries(initdb mapd_thrift DataMgr ${MAPD_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${CUDA_LIBRARIES} ${ZLIB_LIBRARIES} ${LLVM_LIB_FLAGS})
 
 macro(set_dpkg_arch arch_in arch_out)
   if("${arch_in}" STREQUAL "x86_64")
@@ -772,10 +787,10 @@ endif()
 
 set_dpkg_arch(${CMAKE_SYSTEM_PROCESSOR} CPACK_DEBIAN_PACKAGE_ARCHITECTURE)
 
-install(DIRECTORY ThirdParty/licenses DESTINATION "ThirdParty/")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/licenses" DESTINATION "ThirdParty" COMPONENT "doc")
 
 # OmniSciTypes.h local includes (for UDF/UDTF)
-install(FILES Shared/funcannotations.h DESTINATION "Shared/")
+install(FILES Shared/funcannotations.h DESTINATION "Shared/" COMPONENT "include")
 
 # Frontend
 option(MAPD_IMMERSE_DOWNLOAD "Download OmniSci Immerse for packaging" OFF)
@@ -792,6 +807,7 @@ if(MAPD_IMMERSE_DOWNLOAD)
     LOG_DOWNLOAD on
     )
   externalproject_get_property(frontend source_dir)
+
   install(DIRECTORY ${source_dir}/ DESTINATION "frontend/" PATTERN .git EXCLUDE PATTERN node_modules EXCLUDE)
   add_custom_command(TARGET frontend COMMAND ${CMAKE_COMMAND} -E copy_directory ${source_dir} frontend)
   list(APPEND ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_BINARY_DIR}/frontend)
@@ -819,7 +835,7 @@ if(MAPD_DOCS_DOWNLOAD)
     LOG_DOWNLOAD on
     )
   externalproject_get_property(docs source_dir)
-  install(DIRECTORY ${source_dir}/ DESTINATION "docs/" PATTERN .git EXCLUDE)
+  install(DIRECTORY ${source_dir}/ DESTINATION "docs/" PATTERN .git EXCLUDE COMPONENT "doc")
   add_custom_command(TARGET docs COMMAND ${CMAKE_COMMAND} -E copy_directory ${source_dir} docs)
   list(APPEND ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_BINARY_DIR}/docs)
 endif()
@@ -878,23 +894,23 @@ add_custom_target(mapd_java_clean
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/java
   )
 add_dependencies(clean-all mapd_java_clean)
-install(FILES ${CMAKE_SOURCE_DIR}/java/mapd/target/mapd-1.0-SNAPSHOT-jar-with-dependencies.jar DESTINATION bin)
-install(FILES ${CMAKE_SOURCE_DIR}/java/omniscijdbc/target/${OMNISCI_JDBC_JAR} DESTINATION bin)
-install(FILES ${CMAKE_SOURCE_DIR}/java/calcite/target/calcite-1.0-SNAPSHOT-jar-with-dependencies.jar DESTINATION bin)
+install(FILES ${CMAKE_SOURCE_DIR}/java/mapd/target/mapd-1.0-SNAPSHOT-jar-with-dependencies.jar DESTINATION bin COMPONENT "jar")
+install(FILES ${CMAKE_SOURCE_DIR}/java/omniscijdbc/target/${OMNISCI_JDBC_JAR} DESTINATION bin COMPONENT "jar")
+install(FILES ${CMAKE_SOURCE_DIR}/java/calcite/target/calcite-1.0-SNAPSHOT-jar-with-dependencies.jar DESTINATION bin COMPONENT "jar")
 
 set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${ADDITIONAL_MAKE_CLEAN_FILES}")
 
-install(TARGETS initdb omnisci_server DESTINATION bin)
-install(FILES ${CMAKE_BINARY_DIR}/MAPD_GIT_HASH.txt DESTINATION ".")
+install(TARGETS initdb omnisci_server DESTINATION bin COMPONENT "exe")
+install(FILES ${CMAKE_BINARY_DIR}/MAPD_GIT_HASH.txt DESTINATION "." COMPONENT "doc")
 if(ENABLE_CUDA)
-  install(FILES ${CMAKE_BINARY_DIR}/QueryEngine/cuda_mapd_rt.fatbin DESTINATION QueryEngine)
+  install(FILES ${CMAKE_BINARY_DIR}/QueryEngine/cuda_mapd_rt.fatbin DESTINATION QueryEngine COMPONENT "exe")
 endif()
-install(FILES completion_hints.thrift DESTINATION ".")
-install(FILES omnisci.thrift DESTINATION ".")
-install(FILES common.thrift DESTINATION ".")
-install(FILES QueryEngine/serialized_result_set.thrift DESTINATION "QueryEngine/")
+install(FILES completion_hints.thrift DESTINATION "." COMPONENT "thrift")
+install(FILES omnisci.thrift DESTINATION "." COMPONENT "thrift")
+install(FILES common.thrift DESTINATION "." COMPONENT "thrift")
+install(FILES QueryEngine/serialized_result_set.thrift DESTINATION "QueryEngine/" COMPONENT "thrift")
 
-if(NOT PREFER_STATIC_LIBS)
+if(NOT PREFER_STATIC_LIBS AND NOT ENABLE_CONDA)
   install(FILES ${Boost_LIBRARIES} DESTINATION ThirdParty/lib)
 endif()
 
@@ -905,11 +921,11 @@ else()
 endif()
 
 if("${MAPD_EDITION_LOWER}" STREQUAL "os")
-  install(FILES LICENSE.md DESTINATION ".")
+  install(FILES LICENSE.md DESTINATION "." COMPONENT "doc")
 endif()
 
 set(CPACK_RESOURCE_FILE_LICENSE "${EULA_FILE}")
-install(FILES "${EULA_FILE}" DESTINATION ".")
+install(FILES "${EULA_FILE}" DESTINATION "."  COMPONENT "doc")
 
 install(PROGRAMS startomnisci DESTINATION ".")
 install(PROGRAMS scripts/inneromnisci DESTINATION "scripts")

--- a/Embedded/CMakeLists.txt
+++ b/Embedded/CMakeLists.txt
@@ -1,3 +1,2 @@
-add_library(DBEngine SHARED DBEngine.cpp)
-target_link_libraries(DBEngine tinfo ${LLVM_LINKER_FLAGS} QueryRunner DataMgr)
-
+add_library(DBEngine SHARED DBEngine.cpp DBEngine.h)
+target_link_libraries(DBEngine tinfo ${LLVM_LINKER_FLAGS} QueryRunner DataMgr ${Arrow_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${TBB_LIBS})

--- a/ImportExport/CMakeLists.txt
+++ b/ImportExport/CMakeLists.txt
@@ -24,10 +24,10 @@ add_library(ImportExport ${GDAL_SOURCES} ${IMPORT_SOURCES} ${EXPORT_SOURCES} ${S
 target_link_libraries(ImportExport mapd_thrift Logger Shared Catalog DataMgr StringDictionary ${GDAL_LIBRARIES} ${CMAKE_DL_LIBS}
  ${LibArchive_LIBRARIES} ${IMPORT_EXPORT_LIBRARIES} ${Arrow_LIBRARIES})
 
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/ThirdParty/gdal-data DESTINATION "ThirdParty")
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/ThirdParty/gdal-data DESTINATION "ThirdParty" COMPONENT "data")
 add_custom_target(gdal-data ALL COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/ThirdParty/gdal-data" "${CMAKE_BINARY_DIR}/ThirdParty/gdal-data")
 
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/ThirdParty/geo_samples DESTINATION "ThirdParty")
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/ThirdParty/geo_samples DESTINATION "ThirdParty" COMPONENT "data")
 add_custom_target(geo_samples ALL COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/ThirdParty/geo_samples" "${CMAKE_BINARY_DIR}/ThirdParty/geo_samples")
 
 add_library(RowToColumn RowToColumnLoader.cpp RowToColumnLoader.h DelimitedParserUtils.cpp DelimitedParserUtils.h)
@@ -39,4 +39,4 @@ target_link_libraries(StreamImporter RowToColumn mapd_thrift Logger Shared ${CMA
 add_executable(KafkaImporter KafkaImporter.cpp)
 target_link_libraries(KafkaImporter RowToColumn mapd_thrift ${RdKafka_LIBRARIES} Logger Shared ${CMAKE_DL_LIBS} ${Boost_LIBRARIES} ${PROFILER_LIBS})
 
-install(TARGETS StreamImporter KafkaImporter DESTINATION bin)
+install(TARGETS StreamImporter KafkaImporter DESTINATION bin  COMPONENT "exe")

--- a/MigrationMgr/CMakeLists.txt
+++ b/MigrationMgr/CMakeLists.txt
@@ -4,5 +4,5 @@ set(migration_mgr_source_files
 
 add_library(MigrationMgr ${migration_mgr_source_files})
 
-target_link_libraries(MigrationMgr Shared QueryEngine)
+target_link_libraries(MigrationMgr Shared QueryEngine ${Boost_LIBRARIES})
 

--- a/QueryEngine/CMakeLists.txt
+++ b/QueryEngine/CMakeLists.txt
@@ -214,7 +214,7 @@ add_custom_target(QueryEngineFunctionsTargets
     )
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/OmniSciTypes.h DESTINATION ${CMAKE_BINARY_DIR}/QueryEngine/)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OmniSciTypes.h ${CMAKE_CURRENT_BINARY_DIR}/RuntimeFunctions.bc ${CMAKE_CURRENT_BINARY_DIR}/GeosRuntime.bc ${CMAKE_CURRENT_BINARY_DIR}/ExtensionFunctions.ast DESTINATION QueryEngine)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OmniSciTypes.h ${CMAKE_CURRENT_BINARY_DIR}/RuntimeFunctions.bc ${CMAKE_CURRENT_BINARY_DIR}/GeosRuntime.bc ${CMAKE_CURRENT_BINARY_DIR}/ExtensionFunctions.ast DESTINATION QueryEngine COMPONENT "QE")
 
 if(ENABLE_CUDA)
   add_library(QueryEngine ${query_engine_source_files} ${CMAKE_CURRENT_BINARY_DIR}/TopKSort.o ${CMAKE_CURRENT_BINARY_DIR}/InPlaceSortImpl.o ${CMAKE_CURRENT_BINARY_DIR}/ResultSetSortImpl.o ${CMAKE_CURRENT_BINARY_DIR}/GpuInitGroups.o ${CMAKE_CURRENT_BINARY_DIR}/HashJoinRuntimeGpu.o)

--- a/SQLFrontend/CMakeLists.txt
+++ b/SQLFrontend/CMakeLists.txt
@@ -9,4 +9,4 @@ if(ENABLE_KRB5)
   target_link_libraries(omnisql krb5_gss)
 endif()
 
-install(TARGETS omnisql DESTINATION bin)
+install(TARGETS omnisql DESTINATION bin COMPONENT "exe")

--- a/SampleCode/CMakeLists.txt
+++ b/SampleCode/CMakeLists.txt
@@ -56,10 +56,10 @@ target_link_libraries(StreamInsertSimple mapd_sample_thrift ${Boost_LIBRARIES} $
 target_link_libraries(StreamInsert mapd_sample_thrift ${CMAKE_DL_LIBS} ${Boost_LIBRARIES} ${PROFILER_LIBS})
 target_link_libraries(DataGen mapd_sample_thrift ${CMAKE_DL_LIBS} ${PROFILER_LIBS})
 
-install(TARGETS StreamInsertSimple StreamInsert DataGen DESTINATION SampleCode)
-install(DIRECTORY . DESTINATION SampleCode)
+install(TARGETS StreamInsertSimple StreamInsert DataGen DESTINATION SampleCode COMPONENT "data")
+install(DIRECTORY . DESTINATION SampleCode COMPONENT "data")
 install(
     FILES
         ${CMAKE_SOURCE_DIR}/omnisci.thrift
         ${CMAKE_SOURCE_DIR}/cmake/Modules/FindThrift.cmake
-    DESTINATION SampleCode)
+    DESTINATION SampleCode COMPONENT "data")

--- a/ThriftHandler/CommandLineOptions.cpp
+++ b/ThriftHandler/CommandLineOptions.cpp
@@ -798,7 +798,8 @@ boost::optional<int> CommandLineOptions::parse_command_line(
     if (!trim_and_check_file_exists(authMetadata.ca_file_name, "ca file name")) {
       return 1;
     }
-    if (!trim_and_check_file_exists(system_parameters.ssl_trust_store, "ssl trust store")) {
+    if (!trim_and_check_file_exists(system_parameters.ssl_trust_store,
+                                    "ssl trust store")) {
       return 1;
     }
     if (!trim_and_check_file_exists(system_parameters.ssl_keystore, "ssl key store")) {


### PR DESCRIPTION
This is cmake-only continuation of #562, which fixes cmake/conda build problems.
Labels are needed for convenient splitting of the installation files into different packages.

@pearu I hope I have not missed your comments in this PR.