### PR TITLE
Support omniscidb conda-forge feedstock builds with embedding feature [Linux-only]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,7 @@ if(ENABLE_DBE)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
   set(ENABLE_STANDALONE_CALCITE ON)
   add_definitions("-DENABLE_EMBEDDED_DATABASE")
+  add_definitions("-DDBEngine_LIBNAME=\"${CMAKE_SHARED_LIBRARY_PREFIX}DBEngine${CMAKE_SHARED_LIBRARY_SUFFIX}\"")
 endif()
 
 # Code coverage
@@ -854,6 +855,8 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/licenses" DESTINATION 
 
 # OmniSciTypes.h local includes (for UDF/UDTF)
 install(FILES Shared/funcannotations.h DESTINATION "Shared/" COMPONENT "include")
+install(FILES Shared/InlineNullValues.h DESTINATION "Shared/" COMPONENT "include")
+install(FILES Logger/Logger.h DESTINATION "Logger/" COMPONENT "include")
 
 # Frontend
 option(MAPD_IMMERSE_DOWNLOAD "Download OmniSci Immerse for packaging" OFF)
@@ -969,6 +972,7 @@ install(FILES completion_hints.thrift DESTINATION "." COMPONENT "thrift")
 install(FILES omnisci.thrift DESTINATION "." COMPONENT "thrift")
 install(FILES common.thrift DESTINATION "." COMPONENT "thrift")
 install(FILES QueryEngine/serialized_result_set.thrift DESTINATION "QueryEngine/" COMPONENT "thrift")
+install(FILES QueryEngine/extension_functions.thrift DESTINATION "QueryEngine/" COMPONENT "thrift")
 
 if(NOT PREFER_STATIC_LIBS AND NOT ENABLE_CONDA)
   install(FILES ${Boost_LIBRARIES} DESTINATION ThirdParty/lib)

--- a/Embedded/setup.in.py
+++ b/Embedded/setup.in.py
@@ -16,10 +16,10 @@ root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # conda-forge packages omniscidbe and pyomniscidbe are built
 # separately. OMNISCI_ROOT_PATH is defined by the omniscidbe activate
 # script that determines the location of libDBEngine.so and is
-# required in linking Python extension module omniscidbe.
-omnisci_root_path = os.environ.get('OMNISCI_ROOT_PATH',
-                                   os.path.join(sys.exec_prefix, 'opt', 'omnisci'))
-omniscidbe_root = os.path.join(omnisci_root_path, 'lib')
+# required for linking Python extension module omniscidbe.
+extra_library_dirs = []
+if 'OMNISCI_ROOT_PATH' in os.environ:
+    extra_library_dirs.append(os.path.join(os.environ['OMNISCI_ROOT_PATH'], 'lib'))
 
 dbe = Extension(
     "omniscidbe",
@@ -34,8 +34,8 @@ dbe = Extension(
         "@CMAKE_SOURCE_DIR@/ThirdParty/rapidjson",
         "@CMAKE_SOURCE_DIR@/Distributed/os",
     ],
-    library_dirs=pa.get_library_dirs() + ["@CMAKE_CURRENT_BINARY_DIR@", ".", omniscidbe_root],
-    runtime_library_dirs=pa.get_library_dirs() + ["$ORIGIN/../../", omniscidbe_root],
+    library_dirs=pa.get_library_dirs() + ["@CMAKE_CURRENT_BINARY_DIR@", "."] + extra_library_dirs,
+    runtime_library_dirs=pa.get_library_dirs() + ["$ORIGIN/../../"] + extra_library_dirs,
     libraries=pa.get_libraries() + ["DBEngine", "boost_system"],
     extra_compile_args=["-std=c++17", "-DRAPIDJSON_HAS_STDSTRING"],
 )

--- a/Embedded/setup.in.py
+++ b/Embedded/setup.in.py
@@ -7,12 +7,22 @@ from Cython.Build import cythonize
 from distutils.core import setup, Extension
 
 import os
+import sys
 import numpy as np
 import pyarrow as pa
 
 root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# conda-forge packages omniscidbe and pyomniscidbe are built
+# separately. OMNISCI_ROOT_PATH is defined by the omniscidbe activate
+# script that determines the location of libDBEngine.so and is
+# required in linking Python extension module omniscidbe.
+omnisci_root_path = os.environ.get('OMNISCI_ROOT_PATH',
+                                   os.path.join(sys.exec_prefix, 'opt', 'omnisci'))
+omniscidbe_root = os.path.join(omnisci_root_path, 'lib')
+
 dbe = Extension(
-    "dbe",
+    "omniscidbe",
     ["@CMAKE_CURRENT_SOURCE_DIR@/Python/dbe.pyx"],
     language="c++17",
     include_dirs=[
@@ -24,8 +34,8 @@ dbe = Extension(
         "@CMAKE_SOURCE_DIR@/ThirdParty/rapidjson",
         "@CMAKE_SOURCE_DIR@/Distributed/os",
     ],
-    library_dirs=pa.get_library_dirs() + ["@CMAKE_CURRENT_BINARY_DIR@", "."],
-    runtime_library_dirs=pa.get_library_dirs() + ["$ORIGIN/../../"],
+    library_dirs=pa.get_library_dirs() + ["@CMAKE_CURRENT_BINARY_DIR@", ".", omniscidbe_root],
+    runtime_library_dirs=pa.get_library_dirs() + ["$ORIGIN/../../", omniscidbe_root],
     libraries=pa.get_libraries() + ["DBEngine", "boost_system"],
     extra_compile_args=["-std=c++17", "-DRAPIDJSON_HAS_STDSTRING"],
 )
@@ -59,7 +69,7 @@ if False:  # TODO: implement an option?
     ]
 
 setup(
-    name="dbe",
+    name="omniscidbe",
     version="0.1",
     ext_modules=cythonize(
         dbe,

--- a/Embedded/test/test_exceptions.py
+++ b/Embedded/test/test_exceptions.py
@@ -2,7 +2,7 @@
 
 #import sys
 import pytest
-import dbe
+import omniscidbe as dbe
 import ctypes
 import pandas
 import pyarrow

--- a/Embedded/test/test_fsi.py
+++ b/Embedded/test/test_fsi.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 import pyarrow as pa
 from pyarrow import csv
-import dbe
+import omniscidbe as dbe
 import ctypes
 ctypes._dlopen('libDBEngine.so', ctypes.RTLD_GLOBAL)
 

--- a/Embedded/test/test_readcsv.py
+++ b/Embedded/test/test_readcsv.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 import pyarrow as pa
 from pyarrow import csv
-import dbe
+import omniscidbe as dbe
 import ctypes
 ctypes._dlopen('libDBEngine.so', ctypes.RTLD_GLOBAL)
 

--- a/OSDependent/Unix/omnisci_path.cpp
+++ b/OSDependent/Unix/omnisci_path.cpp
@@ -26,10 +26,30 @@
 #include <boost/filesystem/path.hpp>
 
 #include "Logger/Logger.h"
+#ifdef ENABLE_EMBEDDED_DATABASE
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <dlfcn.h>
+#include <link.h>
+#endif
 
 namespace omnisci {
 
 std::string get_root_abs_path() {
+#ifdef ENABLE_EMBEDDED_DATABASE
+  void* const handle = dlopen(DBEngine_LIBNAME, RTLD_LAZY);
+  CHECK(handle);
+  const struct link_map* link_map = 0;
+  const int ret = dlinfo(handle, RTLD_DI_LINKMAP, &link_map);
+  CHECK_EQ(ret, 0);
+  CHECK(link_map);
+  /* Despite the dlinfo man page claim that l_name is absolute path,
+     it is so only when the location path to the library is absolute,
+     say, as specified in LD_LIBRARY_PATH. */
+  boost::filesystem::path abs_exe_dir(boost::filesystem::absolute(
+      boost::filesystem::canonical(std::string(link_map->l_name))));
+#else
 #ifdef __APPLE__
   char abs_exe_path[PROC_PIDPATHINFO_MAXSIZE] = {0};
   auto path_len = proc_pidpath(getpid(), abs_exe_path, sizeof(abs_exe_path));
@@ -40,6 +60,7 @@ std::string get_root_abs_path() {
   CHECK_GT(path_len, 0);
   CHECK_LT(static_cast<size_t>(path_len), sizeof(abs_exe_path));
   boost::filesystem::path abs_exe_dir(std::string(abs_exe_path, path_len));
+#endif  // ifdef ENABLE_EMBEDDED_DATABASE
   abs_exe_dir.remove_filename();
 #ifdef XCODE
   const auto mapd_root = abs_exe_dir.parent_path().parent_path();

--- a/OSDependent/Unix/omnisci_path.cpp
+++ b/OSDependent/Unix/omnisci_path.cpp
@@ -38,18 +38,30 @@ namespace omnisci {
 
 std::string get_root_abs_path() {
 #ifdef ENABLE_EMBEDDED_DATABASE
-  void* const handle = dlopen(DBEngine_LIBNAME, RTLD_LAZY);
-  CHECK(handle);
-  const struct link_map* link_map = 0;
-  const int ret = dlinfo(handle, RTLD_DI_LINKMAP, &link_map);
-  CHECK_EQ(ret, 0);
-  CHECK(link_map);
-  /* Despite the dlinfo man page claim that l_name is absolute path,
-     it is so only when the location path to the library is absolute,
-     say, as specified in LD_LIBRARY_PATH. */
-  boost::filesystem::path abs_exe_dir(boost::filesystem::absolute(
-      boost::filesystem::canonical(std::string(link_map->l_name))));
+  void* const handle = dlopen(DBEngine_LIBNAME, RTLD_LAZY | RTLD_NOLOAD);
+  if (handle) {
+    /* Non-zero handle means that libDBEngine.so has been loaded and
+       the omnisci root path will be determined with respect to the
+       location of the shared library rather than the appliction
+       `/proc/self/exe` path. */
+    const struct link_map* link_map = 0;
+    const int ret = dlinfo(handle, RTLD_DI_LINKMAP, &link_map);
+    CHECK_EQ(ret, 0);
+    CHECK(link_map);
+    /* Despite the dlinfo man page claim that l_name is absolute path,
+       it is so only when the location path to the library is absolute,
+       say, as specified in LD_LIBRARY_PATH. */
+    boost::filesystem::path abs_exe_dir(boost::filesystem::absolute(
+        boost::filesystem::canonical(std::string(link_map->l_name))));
+    abs_exe_dir.remove_filename();
+#ifdef XCODE
+    const auto mapd_root = abs_exe_dir.parent_path().parent_path();
 #else
+    const auto mapd_root = abs_exe_dir.parent_path();
+#endif
+    return mapd_root.string();
+  }
+#endif
 #ifdef __APPLE__
   char abs_exe_path[PROC_PIDPATHINFO_MAXSIZE] = {0};
   auto path_len = proc_pidpath(getpid(), abs_exe_path, sizeof(abs_exe_path));
@@ -60,7 +72,6 @@ std::string get_root_abs_path() {
   CHECK_GT(path_len, 0);
   CHECK_LT(static_cast<size_t>(path_len), sizeof(abs_exe_path));
   boost::filesystem::path abs_exe_dir(std::string(abs_exe_path, path_len));
-#endif  // ifdef ENABLE_EMBEDDED_DATABASE
   abs_exe_dir.remove_filename();
 #ifdef XCODE
   const auto mapd_root = abs_exe_dir.parent_path().parent_path();

--- a/QueryEngine/NativeCodegen.cpp
+++ b/QueryEngine/NativeCodegen.cpp
@@ -1352,7 +1352,7 @@ llvm::Module* read_template_module(llvm::LLVMContext& context) {
 
   auto buffer_or_error = llvm::MemoryBuffer::getFile(omnisci::get_root_abs_path() +
                                                      "/QueryEngine/RuntimeFunctions.bc");
-  CHECK(!buffer_or_error.getError());
+  CHECK(!buffer_or_error.getError()) << "root path=" << omnisci::get_root_abs_path();
   llvm::MemoryBuffer* buffer = buffer_or_error.get().get();
 
   auto owner = llvm::parseBitcodeFile(buffer->getMemBufferRef(), context);
@@ -1380,7 +1380,7 @@ llvm::Module* read_libdevice_module(llvm::LLVMContext& context) {
   }
 
   auto buffer_or_error = llvm::MemoryBuffer::getFile(cuda_path.c_str());
-  CHECK(!buffer_or_error.getError());
+  CHECK(!buffer_or_error.getError()) << "cuda_path=" << cuda_path.c_str();
   llvm::MemoryBuffer* buffer = buffer_or_error.get().get();
 
   auto owner = llvm::parseBitcodeFile(buffer->getMemBufferRef(), context);
@@ -1398,7 +1398,7 @@ llvm::Module* read_geos_module(llvm::LLVMContext& context) {
 
   auto buffer_or_error = llvm::MemoryBuffer::getFile(omnisci::get_root_abs_path() +
                                                      "/QueryEngine/GeosRuntime.bc");
-  CHECK(!buffer_or_error.getError());
+  CHECK(!buffer_or_error.getError()) << "root path=" << omnisci::get_root_abs_path();
   llvm::MemoryBuffer* buffer = buffer_or_error.get().get();
 
   auto owner = llvm::parseBitcodeFile(buffer->getMemBufferRef(), context);

--- a/python/setup.py
+++ b/python/setup.py
@@ -61,7 +61,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3 :: Only",
     ],
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests',)),
     version=VERSION,
     install_requires=install_requires,
     extras_require=extra_requires,


### PR DESCRIPTION
This PR includes:
- determine the omniscidb root path from the location of libDBEngine.so
- include a complete set of thrift files to installation
- use OMNISCI_ROOT_PATH environment variable to determine the root path for building Python omniscidbe extension module
- Python extension module `dbe` is renamed to `omniscidbe`

This PR is used in https://github.com/conda-forge/omniscidb-feedstock/pull/39 to build the following conda-forge packages:
- omniscdb-common, linux only
- omniscidb, cpu and cuda builds, linux only
- omniscidbe, cpu and cuda builds, linux only
- pyomniscidb, python versions 3.6, 3.7, 3.8, linux, windows, os
- pyomniscidbe, cpu and cuda builds, python version 3.6, 3.7, 3.8, linux only