### PR TITLE
Implement data removal for dropped FSI tables.

### DIFF
--- a/DataMgr/ForeignStorage/ArrowForeignStorage.cpp
+++ b/DataMgr/ForeignStorage/ArrowForeignStorage.cpp
@@ -60,6 +60,8 @@ class ArrowForeignStorageBase : public PersistentForeignStorageInterface {
                       const SQLTypeInfo& sql_type,
                       const size_t numBytes) override;
 
+  void dropTable(const int db_id, const int table_id) override;
+
   void parseArrowTable(Catalog_Namespace::Catalog* catalog,
                        std::pair<int, int> table_key,
                        const std::string& type,
@@ -613,6 +615,13 @@ int8_t* ArrowForeignStorageBase::tryZeroCopy(const ChunkKey& chunk_key,
   auto offsets_buffer = reinterpret_cast<const uint32_t*>(array_data->buffers[1]->data());
   auto string_buffer_offset = offsets_buffer[offset + array_data->offset];
   return data + string_buffer_offset;
+}
+
+void ArrowForeignStorageBase::dropTable(const int db_id, const int table_id) {
+  auto it = m_columns.lower_bound({db_id, table_id, 0});
+  while (it->first[0] == db_id && it->first[1] == table_id) {
+    it = m_columns.erase(it);
+  }
 }
 
 std::shared_ptr<arrow::ChunkedArray>

--- a/DataMgr/ForeignStorage/ForeignStorageInterface.cpp
+++ b/DataMgr/ForeignStorage/ForeignStorageInterface.cpp
@@ -165,6 +165,12 @@ Data_Namespace::AbstractBufferMgr* ForeignStorageInterface::lookupBufferManager(
   return it_ok.first->second.get();
 }
 
+void ForeignStorageInterface::dropBufferManager(const int db_id, const int table_id) {
+  std::lock_guard<std::mutex> persistent_storage_interfaces_lock(
+      persistent_storage_interfaces_mutex_);
+  managers_map_.erase(std::make_pair(db_id, table_id));
+}
+
 void ForeignStorageInterface::registerPersistentStorageInterface(
     std::unique_ptr<PersistentForeignStorageInterface> persistent_foreign_storage) {
   std::lock_guard<std::mutex> persistent_storage_interfaces_lock(

--- a/DataMgr/ForeignStorage/ForeignStorageInterface.h
+++ b/DataMgr/ForeignStorage/ForeignStorageInterface.h
@@ -52,6 +52,7 @@ class PersistentForeignStorageInterface {
                              const TableDescriptor& td,
                              const std::list<ColumnDescriptor>& cols,
                              Data_Namespace::AbstractBufferMgr* mgr) = 0;
+  virtual void dropTable(const int db_id, const int table_id) = 0;
   virtual std::string getType() const = 0;
 };
 
@@ -205,7 +206,7 @@ class ForeignStorageBufferMgr : public Data_Namespace::AbstractBufferMgr {
   }
 
   void removeTableRelatedDS(const int db_id, const int table_id) override {
-    UNREACHABLE();
+    persistent_foreign_storage_->dropTable(db_id, table_id);
   }
 
  private:
@@ -227,6 +228,7 @@ class ForeignStorageInterface {
 
   Data_Namespace::AbstractBufferMgr* lookupBufferManager(const int db_id,
                                                          const int table_id);
+  void dropBufferManager(const int db_id, const int table_id);
 
   void registerPersistentStorageInterface(
       std::unique_ptr<PersistentForeignStorageInterface> persistent_foreign_storage);


### PR DESCRIPTION
Currently, when FSI table is dropped its data still lives. This creates memory leaks when OmniSci is used as a Modin backend. This patch implements data removal for dropped tables stored in FSI.